### PR TITLE
Remove jis common css

### DIFF
--- a/WAIC-CODE/WAIC-CODE-0003-01.html
+++ b/WAIC-CODE/WAIC-CODE-0003-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0003-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0003-02.html
+++ b/WAIC-CODE/WAIC-CODE-0003-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0003-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0003-03.html
+++ b/WAIC-CODE/WAIC-CODE-0003-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0003-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0003-04.html
+++ b/WAIC-CODE/WAIC-CODE-0003-04.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0003-04</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0004-01-ref1.html
+++ b/WAIC-CODE/WAIC-CODE-0004-01-ref1.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0004-01-ref1</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0004-01-ref2.html
+++ b/WAIC-CODE/WAIC-CODE-0004-01-ref2.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0004-01-ref2</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0004-01-ref3.html
+++ b/WAIC-CODE/WAIC-CODE-0004-01-ref3.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0004-01-ref3</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0004-01-ref4.html
+++ b/WAIC-CODE/WAIC-CODE-0004-01-ref4.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0004-01-ref4</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0004-01.html
+++ b/WAIC-CODE/WAIC-CODE-0004-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0004-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0005-01.html
+++ b/WAIC-CODE/WAIC-CODE-0005-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>ウェブアクセシビリティ基盤委員会</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0006-01.html
+++ b/WAIC-CODE/WAIC-CODE-0006-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0006-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0006-02.html
+++ b/WAIC-CODE/WAIC-CODE-0006-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0006-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0006-03.html
+++ b/WAIC-CODE/WAIC-CODE-0006-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0006-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0007-01-ref.html
+++ b/WAIC-CODE/WAIC-CODE-0007-01-ref.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0007-01-ref</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0007-01.html
+++ b/WAIC-CODE/WAIC-CODE-0007-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0007-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0007-02.html
+++ b/WAIC-CODE/WAIC-CODE-0007-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0007-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0008-01.html
+++ b/WAIC-CODE/WAIC-CODE-0008-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0008-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0009-01.html
+++ b/WAIC-CODE/WAIC-CODE-0009-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0009-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0010-01.html
+++ b/WAIC-CODE/WAIC-CODE-0010-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0010-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0010-02-20160128-01.html
+++ b/WAIC-CODE/WAIC-CODE-0010-02-20160128-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0010-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0010-02-20160128.html
+++ b/WAIC-CODE/WAIC-CODE-0010-02-20160128.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0010-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0010-02.html
+++ b/WAIC-CODE/WAIC-CODE-0010-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0010-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0010-03-20160128.html
+++ b/WAIC-CODE/WAIC-CODE-0010-03-20160128.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0010-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0010-03.html
+++ b/WAIC-CODE/WAIC-CODE-0010-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0010-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0011-01.html
+++ b/WAIC-CODE/WAIC-CODE-0011-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0011-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0011-02.html
+++ b/WAIC-CODE/WAIC-CODE-0011-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0011-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0012-01.html
+++ b/WAIC-CODE/WAIC-CODE-0012-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0012-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 <style>
 #labelrow label {
   margin: 1em 9em 0 0;

--- a/WAIC-CODE/WAIC-CODE-0012-02.html
+++ b/WAIC-CODE/WAIC-CODE-0012-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0012-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0012-03.html
+++ b/WAIC-CODE/WAIC-CODE-0012-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0012-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0012-04.html
+++ b/WAIC-CODE/WAIC-CODE-0012-04.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0012-04</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/WAIC-CODE/WAIC-CODE-0012-05.html
+++ b/WAIC-CODE/WAIC-CODE-0012-05.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0012-05</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0013-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0013-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0013-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0014-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0014-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0014-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0014-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0014-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0014-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0014-03.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0014-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0014-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0015-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0015-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0015-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 <style>
 em.test-0015-normal {
   font-style: normal;

--- a/wip/WAIC-CODE/WAIC-CODE-0015-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0015-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0015-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 <style>
 strong.test-0015-normal {
   font-weight: normal;

--- a/wip/WAIC-CODE/WAIC-CODE-0015-03.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0015-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0015-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0015-04.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0015-04.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0015-04</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0015-05.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0015-05.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0015-05</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0015-06.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0015-06.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0015-06</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0016-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0016-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0016-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0017-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0017-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0017-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0017-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0017-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0017-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0018-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0018-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0018-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0018-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0018-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0018-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0018-03.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0018-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0018-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0019-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0019-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0019-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0019-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0019-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0019-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0019-03.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0019-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0019-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0019-04.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0019-04.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0019-04</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0019-05.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0019-05.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0019-05</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0019-06.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0019-06.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0019-06</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0022-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0022-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0022-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0023-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0023-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0023-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0023-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0023-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0023-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0024-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0024-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0024-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0024-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0024-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0024-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0025-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0025-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0025-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0026-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0026-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0026-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0026-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0026-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0026-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0026-03.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0026-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0026-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0027-01.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0027-01.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0027-01</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0027-02.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0027-02.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0027-02</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>

--- a/wip/WAIC-CODE/WAIC-CODE-0027-03.html
+++ b/wip/WAIC-CODE/WAIC-CODE-0027-03.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <title>WAIC-CODE-0027-03</title>
 <meta name="copyright" content="This document is licensed under a Creative Commons">
-<link rel="stylesheet" type="text/css" href="../jis-common.css" media="screen, print">
 </head>
 
 <body>


### PR DESCRIPTION
jis-common.css を適用している link 要素を削除しました。#64
レビューをお願いします。2名以上の方からLGTMをいただけたら master にマージします。