### PR TITLE
0029-05 テストタイトルの xhtml 表記を大文字に変更

### DIFF
--- a/WAIC-TEST/HTML/WAIC-TEST-0029-05.md
+++ b/WAIC-TEST/HTML/WAIC-TEST-0029-05.md
@@ -4,7 +4,7 @@
 WAIC-TEST-0029-05
 
 # テストのタイトル
-aria-describedby 属性による説明ラベルの提供 (input要素 : xhtml文書)
+aria-describedby 属性による説明ラベルの提供 (input要素 : XHTML文書)
 
 # テストの目的
 application/xhtml+xml の MIME タイプのドキュメントにおいて、button 要素に aria-describedby 属性で関連付けをおこなった場合、関連付けられた要素の内容が読み上げられるかの確認


### PR DESCRIPTION
https://github.com/waic/as_test/issues/165#issuecomment-1257192166

> aria-describedby 属性による説明ラベルの提供 (input要素 : xhtml文書)
> の「xhtml」を「XHTML」にしたいです。
