### PR TITLE
ARIA24 / 0053-01 のテストを追加

### DIFF
--- a/WAIC-CODE/WAIC-CODE-0053-01.html
+++ b/WAIC-CODE/WAIC-CODE-0053-01.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>WAIC-CODE-0053-01</title>
+<meta name="copyright" content="This document is licensed under a Creative Commons 4.0">
+<link rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
+<meta name="author" content="ウェブアクセシビリティ基盤委員会（WAIC）">
+<style>
+.icon {
+    font-family: 'Material Icons Outlined';
+}
+.icon-star-bg::before {
+    content: 'star';
+}
+.font-family-toggle *:not([role="img"]) {
+    font-family: Verdana, sans-serif !important;
+}
+</style>
+</head>
+<body id="font-family-toggle">
+<script>
+    function fontFamilyToggle() {
+    var element = document.getElementById("font-family-toggle");
+    element.classList.toggle("font-family-toggle");
+}
+</script>    
+<p><strong>アイコンフォントA</strong></p>
+<p><span class="icon icon-star-bg"></span> </p>
+<p><strong>アイコンフォントB</strong></p>
+<p><span class="icon icon-star-bg" role="img" aria-label="Favorite"></span></p>
+<button onclick="fontFamilyToggle()">フォントファミリーを変更</button>
+</body>
+</html>

--- a/WAIC-TEST/HTML/WAIC-TEST-0053-01.md
+++ b/WAIC-TEST/HTML/WAIC-TEST-0053-01.md
@@ -1,0 +1,75 @@
+# テスト ID
+WAIC-TEST-0053-01
+
+# テストのタイトル
+アイコンフォントに意味を付与するために role="img" を使用
+
+# テストの目的
+role="img" が指定されたアイコンフォントは、フォントファミリーが上書きされても正しく表示されることの確認
+
+# テストの対象となる達成基準 
+1.3.1
+
+# 関連する達成方法 (複数)
+ARIA24
+
+# テストコード (テストファイルへのリンク)
+[WAIC-CODE-0053-01](https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0053-01.html)
+
+# テストコードのソース (抜粋)
+```HTML
+<script>
+    function fontFamilyToggle() {
+    var element = document.getElementById("font-family-toggle");
+    element.classList.toggle("font-family-toggle");
+}
+</script>    
+<p><strong>アイコンフォントA</strong></p>
+<p><span class="icon icon-star-bg"></span> </p>
+<p><strong>アイコンフォントB</strong></p>
+<p><span class="icon icon-star-bg" role="img" aria-label="Favorite"></span></p>
+<button onclick="fontFamilyToggle()">フォントファミリーを変更</button>
+```
+
+```CSS
+.icon {
+    font-family: 'Material Icons Outlined';
+}
+.icon-star-bg::before {
+    content: 'star';
+}
+.font-family-toggle *:not([role="img"]) {
+    font-family: Verdana, sans-serif !important;
+}
+```
+# テスト手順 (視覚閲覧環境)
+「フォントファミリーを変更」ボタンをクリックして、フォントを切り替える
+
+# 期待される結果 (視覚閲覧環境)
+次の2点の両方を満たす
+1.「アイコンフォントA」のアイコンフォントの表示が「スター」に切り替わる
+2.「アイコンフォントB」のアイコンフォントの表示は変更されない
+
+# テスト実施時の注意点 (視覚閲覧環境)
+なし
+
+# テスト手順 (音声閲覧環境)
+テストファイルを開き、タブキーや矢印キーを使いフォーカスをアイコンフォントに移動させ、どのように読み上げるかを確認
+
+## テスト手順 1.
+「アイコンフォントA」のアイコンフォントにフォーカスをあわせる
+
+### 期待される結果 1.
+「スター」というアイコンフォント名が通知される
+
+## テスト手順 2.
+「アイコンフォントB」のアイコンフォントにフォーカスをあわせる。
+
+### 期待される結果 2.
+「Favorite画像」という説明ラベルが通知される
+
+# テスト実施時の注意点 (音声閲覧環境)
+なし
+
+# 関連する要素や属性
+role属性、aria-label属性


### PR DESCRIPTION
ARIA 24 の事例1 を元としたテストの作成。
https://waic.jp/translations/WCAG21/Techniques/aria/ARIA24#example-1-star-icon-font-used-as-an-indicator-not-interactive

ARIA24 事例2と事例3は、擬似要素によるアイコンフォントの指定方法と、HTML側での role属性と aria-label 属性の指定方法が事例1 と類似しているため、テスト作成が必要かを確認したいです。
また、ARIA24 事例4は aria-hidden属性が使用されている点が事例1～3と異なるためテストの作成が必要かと思いますが、事例1と同様の作成方法で問題がないか確認したいです。

※ライセンス Apache License 2.0 の Google Material Icons を CDN で使用

