### PR TITLE
テストケース 0044-01 (ARIA11) の修正

### DIFF
--- a/WAIC-CODE/WAIC-CODE-0044-01-ref1.html
+++ b/WAIC-CODE/WAIC-CODE-0044-01-ref1.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<html lang="ja">
+
+<head>
+    <meta charset="utf-8">
+    <title>WAIC-CODE-0044-01-ref1</title>
+    <meta name="copyright" content="This document is licensed under a Creative Commons 4.0">
+    <link rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+    <meta name="author" content="ウェブアクセシビリティ基盤委員会（WAIC）">
+</head>
+
+<body>
+    <h1>世界への扉 旅行プランをご紹介</h1>
+    <p><a href="WAIC-CODE-0044-01.html">WAIC-CODE-0044-01に戻る</a></p>
+
+</body>
+
+</html>

--- a/WAIC-CODE/WAIC-CODE-0044-01.html
+++ b/WAIC-CODE/WAIC-CODE-0044-01.html
@@ -54,6 +54,11 @@
             cursor: pointer;
         }
 
+        #sitelookup form button[type="submit"]:focus {
+            outline: 2px solid #005a9c;
+            outline-offset: 2px;
+        }
+
         #nav {
             background-color: #333;
             color: #fff;
@@ -121,10 +126,10 @@
         </div>
         <div id="nav" role="navigation">
             <ul>
-                <li><a href="#">ホーム</a></li>
-                <li><a href="#">サービス</a></li>
-                <li><a href="#">会社概要</a></li>
-                <li><a href="#">お問い合わせ</a></li>
+                <li><a href="WAIC-CODE-0044-01-ref1.html">ホーム</a></li>
+                <li><a href="WAIC-CODE-0044-01-ref1.html">サービス</a></li>
+                <li><a href="WAIC-CODE-0044-01-ref1.html">会社概要</a></li>
+                <li><a href="WAIC-CODE-0044-01-ref1.html">お問い合わせ</a></li>
             </ul>
         </div>
         <div id="content" role="main">

--- a/WAIC-TEST/HTML/WAIC-TEST-0044-01.md
+++ b/WAIC-TEST/HTML/WAIC-TEST-0044-01.md
@@ -12,15 +12,15 @@ WAIC-TEST-0044-01
 
 # テストの対象となる達成基準 (複数)
 
-1.3.1, 2.4.1
+1.3.1, 1.3.6, 2.4.1
 
 # 関連する達成方法 (複数)
 
-H69, SCR28
+ARIA11
 
 # テストコード (テストファイルへのリンク)
 
-[WAIC-CODE-00xx-01](https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-00xx-01.html)
+[WAIC-CODE-0044-01](https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0044-01.html)
 
 # テストコードのソース (抜粋)
 


### PR DESCRIPTION
#193 をマージしましたが、2024年1月定例会で誤記があるとご指摘をいただいたので、確認しました。

以下を修正しています。

* 達成基準、達成方法の修正
* テストファイルへのリンクの修正
* テストコードで外部へのリンクを「戻る」だけの別ページに変更（mdファイルの抜粋は直していない）
* テストコードで検索ボタンのフォーカスインジケーターを見やすくした