### PR TITLE
テストファイルへのリンクを追加

### DIFF
--- a/WAIC-TEST/HTML/WAIC-TEST-0142-01.md
+++ b/WAIC-TEST/HTML/WAIC-TEST-0142-01.md
@@ -18,6 +18,10 @@ role="status" を持つ要素の内容が更新された際に、変更が通知
 
 ARIA22
 
+# テストコード (テストファイルへのリンク)
+
+[WAIC-CODE-0142-01](https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0142-01.html)
+
 # テストコードのソース (抜粋)
 
 ```html

--- a/WAIC-TEST/HTML/WAIC-TEST-0143-01.md
+++ b/WAIC-TEST/HTML/WAIC-TEST-0143-01.md
@@ -18,6 +18,10 @@ role="log"を持つ要素の内容を更新した際に、更新内容だけが�
 
 ARIA23
 
+# テストコード (テストファイルへのリンク)
+
+[WAIC-CODE-0143-01](https://waic.github.io/as_test/WAIC-CODE/WAIC-CODE-0143-01.html)
+
 # テストコードのソース (抜粋)
 
 ```html


### PR DESCRIPTION
https://github.com/waic/as_info/issues/167 の作業中に、テストファイルへのリンクがないテストを見つけました。